### PR TITLE
Fix mocha test failure

### DIFF
--- a/src/tool.js
+++ b/src/tool.js
@@ -2,7 +2,8 @@ exports.genURL = (urlLength) => {
   var urlString = "";
   const sourceLetters = "ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789";
 
-  for(var genLoopIndex = 0; genLoopIndex < 50; genLoopIndex++){
+  // We need to make sure the loop only goes on as long as requested by the function param
+  for(var genLoopIndex = 0; genLoopIndex < urlLength; genLoopIndex++){
 
     // Add a random letter to the urlString
     urlString += sourceLetters.charAt(Math.random() * (sourceLetters.length - 1))


### PR DESCRIPTION
The mocha test expects the generated URL to match the length of the input urlLength param. Changing the max val in the for loop ensures the generated URL is the correct length.